### PR TITLE
Change error handling style in each of the create functions

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@ var app = express();
 var bodyParser = require('body-parser');
 
 app.get('/', function (req, res) {
-    res.send('This is the official parq API. For more information, visit https://github.com/parq-app/parq-api');
+    res.send('This is the official <i>parq</i> API. For more information, visit <a href=https://github.com/parq-app/parq-api>our GitHub</a>');
 });
 
 app.use(bodyParser.json());

--- a/controllers/reservations.js
+++ b/controllers/reservations.js
@@ -13,6 +13,12 @@ router.get("/:id", function(req, res) {
 
 // Create and reserve a new reservation
 router.post('/', function(req, res) {
+  if (!req.body.hasOwnProperty('userId') || !req.body.hasOwnProperty('latitude') ||
+     !req.body.hasOwnProperty('longitude')) {
+    res.status(400).json({error: "Missing expected body parameter."});
+    return;
+  }
+
   Reservation.reserve(req.body.userId, req.body.latitude, req.body.longitude)
     .then(function(reservation) {
       res.status(201).json(reservation);

--- a/controllers/spots.js
+++ b/controllers/spots.js
@@ -13,18 +13,19 @@ router.get('/:id', function(req, res) {
 
 // Create a new spot
 router.post('/', function(req, res) {
-  if (req.body.hasOwnProperty('userId') && req.body.hasOwnProperty('addr') &&
-     req.body.hasOwnProperty('title') && req.body.hasOwnProperty('lat') &&
-     req.body.hasOwnProperty('long')) {
-    Spot.create(req.body.userId, req.body.addr, req.body.lat, req.body.long, req.body.title)
-     .then(function(spot) {
-       res.status(201).json(spot);
-     }).catch(function(error) {
-       res.status(500).json({error: error});
-     });
-  } else {
+  if (!req.body.hasOwnProperty('userId') || !req.body.hasOwnProperty('addr') ||
+     !req.body.hasOwnProperty('title') || !req.body.hasOwnProperty('lat') ||
+     !req.body.hasOwnProperty('long')) {
     res.status(400).json({error: "Missing expected body parameter."});
+    return;
   }
+
+  Spot.create(req.body.userId, req.body.addr, req.body.lat, req.body.long, req.body.title)
+    .then(function(spot) {
+      res.status(201).json(spot);
+    }).catch(function(error) {
+      res.status(500).json({error: error});
+    });
 });
 
 // Update a spot

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -13,15 +13,16 @@ router.get('/:id', function(req, res) {
 
 // Create a new user
 router.post('/', function(req, res) {
-  if (req.body.hasOwnProperty('email') && req.body.hasOwnProperty('password')) {
-    User.create(req.body.email, req.body.password).then(function(user) {
-      res.status(201).json(user);
-    }).catch(function(error) {
-      res.status(500).json({error: error});
-    });
-  } else {
+  if (!req.body.hasOwnProperty('email') || !req.body.hasOwnProperty('password')) {
     res.status(400).json({error: "Missing expected body parameter."})
+    return;
   }
+
+  User.create(req.body.email, req.body.password).then(function(user) {
+    res.status(201).json(user);
+  }).catch(function(error) {
+    res.status(500).json({error: error});
+  });
 });
 
 // Update a user

--- a/models/spot.js
+++ b/models/spot.js
@@ -29,18 +29,17 @@ exports.get = function(spotId) {
 };
 
 exports.update = function(spotId, attrs) {
-  // Check that id is not null
   if (spotId == null) return Promise.reject("Null spot ID");
 
   return firebaseRef.child(spotId).update(attrs);
 };
 
 exports.reserve = function(spotId) {
-    return firebaseRef.child(spotId).update({"isReserved": true});
+  return firebaseRef.child(spotId).update({"isReserved": true});
 };
 
 exports.free = function(spotId) {
-    return firebaseRef.child(spotId).update({"isReserved": false});
+  return firebaseRef.child(spotId).update({"isReserved": false});
 };
 
 function Spot(userId, addr, geohash, title, rating, numRatings, cost, id) {
@@ -53,7 +52,7 @@ function Spot(userId, addr, geohash, title, rating, numRatings, cost, id) {
     isReserved: false,
     rating: rating,
     numRatings: numRatings,
-    costPerHour: cost 
+    costPerHour: cost
   };
 };
 exports.Spot = Spot;

--- a/models/user.js
+++ b/models/user.js
@@ -26,7 +26,6 @@ exports.update = function(id, attrs) {
   return firebaseRef.child(id).update(attrs);
 }
 
-
 function User(email, id) {
   this.id = id;
   this.attributes = {


### PR DESCRIPTION
Moving towards a C-style error handling. I only have it on each of the create functions because I don't have a great way of doing it on the update functions (hence my playing with the Firebase rules stuff). Might be best to just remove all of this error checking from the API and let Firebase handle everything?