### PR TITLE
Add endpoint for setting reservation state to 'navigating'

### DIFF
--- a/controllers/reservations.js
+++ b/controllers/reservations.js
@@ -27,6 +27,15 @@ router.post('/', function(req, res) {
     });
 });
 
+// Start navigation to spot with given id.
+router.put("/:id/navigating", function(req, res) {
+  Reservation.navigating(req.params.id).then(function(reservation) {
+    res.status(200).json(reservation);
+  }).catch(function(error) {
+    res.status(500).json({error: error});
+  });
+});
+
 // Occupy spot passed in the id
 router.put("/:id/occupy", function(req, res) {
   Reservation.occupy(req.params.id).then(function(reservation) {

--- a/models/reservation.js
+++ b/models/reservation.js
@@ -118,7 +118,7 @@ exports.reserve = function(driverId, latitude, longitude) {
 };
 
 /* Change status to navigating */
-exports.accept = function(reservationId) {
+exports.navigating = function(reservationId) {
   return exports.updateStatus(reservationId, 'navigating');
 };
 


### PR DESCRIPTION
We want to set reservation state to navigating as soon as they click 'navigate them to spot' so that the app can resume in that state if they close it. 

@matthewgrossman @nickcharles 