### PR TITLE
Make the /occupy endpoint return the updated reservation

### DIFF
--- a/models/reservation.js
+++ b/models/reservation.js
@@ -126,7 +126,11 @@ exports.navigating = function(reservationId) {
 exports.occupy = function(reservationId) {
   return exports.updateStatus(reservationId, 'occupied')
     .then(setStartTime)
-    .then(addReservationToActive);
+    .then(addReservationToActive)
+    .then(function(oldReservation) {
+      // Return the updated resrvation
+      return exports.get(reservationId);  
+    });
 };
 
 /* Change reservation status, remove from both of the active lists */


### PR DESCRIPTION
before it was returning the old reservation which didn't have timeStart 

@matthewgrossman @nickcharles 