### PR TITLE
Refactored states and moved around code

### DIFF
--- a/controllers/reservations.js
+++ b/controllers/reservations.js
@@ -28,8 +28,8 @@ router.post('/', function(req, res) {
 });
 
 // Start navigation to spot with given id.
-router.put("/:id/navigating", function(req, res) {
-  Reservation.navigating(req.params.id).then(function(reservation) {
+router.put("/:id/accept", function(req, res) {
+  Reservation.accept(req.params.id).then(function(reservation) {
     res.status(200).json(reservation);
   }).catch(function(error) {
     res.status(500).json({error: error});
@@ -52,6 +52,22 @@ router.put("/:id/finish", function(req, res) {
   }).catch(function(error) {
     res.status(500).json({error: error});
   });
+});
+
+// Review spot occupation passed in the id
+router.put("/:id/review", function(req, res) {
+  if (!req.body.hasOwnProperty('id') || !req.body.hasOwnProperty('rating') ||
+     !req.body.hasOwnProperty('comment')) {
+    res.status(400).json({error: "Missing expected body parameter."});
+    return;
+  }
+
+  Reservation.review(req.body.id, req.body.rating, req.body.comment)
+    .then(function(reservation) {
+      res.status(201).json(reservation);
+    }).catch(function(error) {
+      res.status(500).json({error: error});
+    });
 });
 
 module.exports = router;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -8,7 +8,7 @@ var usersRef = firebaseRef.child("users");
 var users = [
   {email: "mrgrossm@umich.edu", password: "m", id: "", firstName: "Matt", lastName: "Gross Man"},
   {email: "nickmorg@umich.edu", password: "n", id: "", firstName: "Nick", lastName: "Mo"},
-  {email: "kenzshelley@gmail.com", password: "p", id: "", firstName: "Kenz", lastName: "Shelley"}
+  {email: "kenzshelley@gmail.com", password: "p", id: "", firstName: "Kenz", lastName: "Smelley"}
 ];
 
 // Tries to delete a given user, catching an error if it happens

--- a/test/models/reservation.js
+++ b/test/models/reservation.js
@@ -1,5 +1,4 @@
 var assert = require('assert');
-
 var Helpers = require('../helpers');
 
 var Reservation = require('../../models/reservation');
@@ -76,7 +75,7 @@ describe('Reservation', function() {
     });
 
     it('accepts a new reservation and checks new status', function(done) {
-      Reservation.occupy(reservation.id)
+      Reservation.accept(reservation.id)
         .then(function(res) {
           reservation = res;
           assert.equal(reservation.attributes.status, "accepted");
@@ -192,16 +191,6 @@ describe('Reservation', function() {
         });
     });
 
-    it('makes sure that the reservationId was removed from driver', function(done) {
-      User.get(reservation.attributes.driverId)
-        .then(function(user) {
-          assert(!user.attributes.hasOwnProperty('activeDriverReservations'));
-          done();
-        }).catch(function(err) {
-          done(err);
-        });
-    });
-
     it('checks that the reserved loc is in the free list', function(done) {
       Loc.getAllLocs()
         .then(function(locs) {
@@ -239,7 +228,7 @@ describe('Reservation', function() {
     });
 
     it('checks reviewed status on reservation', function(done) {
-      Reservation.finish(reservation.id)
+      Reservation.review(reservation.id, 3.5, "sux")
         .then(function(res) {
           reservation = res;
           assert.equal(reservation.attributes.status, 'reviewed');


### PR DESCRIPTION
@kenzshelley @nickcharles 
## What
This should implement the states and their requirements found in the wiki page.

This moves around a fair amount of functionality in reservation to where it should be, such as in Spot or User. Also, the way we create a reservation is now in a different order to avoid doing unnecessary FB requests. These are internal changes and shouldn't matter.

## What does matter interface-wise
- There are now the endpoints `/accept` and `/review`. There is no longer `/navigating` or w/e it was
- The data returned from activeList is now in the format {resid: resid}, as opposed to the old {resid, {"resId": resid} }. This will change how we parse the JSON in the app

